### PR TITLE
[FIX] Propeller metatag

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -20,7 +20,7 @@ export default {
   additionalMetaTags: 
     [
       {
-        property: 'propeller',
+        name: 'propeller',
         content: '212136656dc025f7fb532bc66fd47bf8'
       }
     ]


### PR DESCRIPTION
The tag should be `name` and not `property`.