### PR TITLE
[BUGFIX] Fix bug for quests with multiple spaces

### DIFF
--- a/pages/quests.tsx
+++ b/pages/quests.tsx
@@ -154,7 +154,7 @@ function NPCQuests({ npc, playerInfo, playerQuestData }: { npc: NPC, playerInfo:
                                 {
                                     playerInfo.map((player, index) => {
                                         let questStatus = CharacterBoxStatus.Disabled;
-                                        switch (playerQuestData[player.playerID][info.QuestName.replace(/ /, "_")]) {
+                                        switch (playerQuestData[player.playerID][info.QuestName.replace(/ /g, "_")]) {
                                             case 1:
                                                 questStatus = CharacterBoxStatus.Complete;
                                                 break;


### PR DESCRIPTION
Had a bug where I wasn't replacing quest names with multiple spaces to `_` only the first instance, this is to fix it.