### PR TITLE
[Feature] Improved loading display

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -217,7 +217,7 @@ export default function Layout({
     }
 
     useEffect(() => {
-        if (appContext.status == AppStatus.LiveData || appContext.status == AppStatus.StaticData) {
+        if (appContext.status == AppStatus.LiveData || appContext.status == AppStatus.StaticData || appContext.status == AppStatus.NoData) {
             setValidState(true);
         }
         else {


### PR DESCRIPTION
Set the body to not load at all, as there are hydration errors when the data doesn't exist yet. That part might take a lot more work, but currently the header and footer of the page can load before any live-data comes in.

Need to test with static data too.