### PR TITLE
[Feature] Locked bubble hover enable

### DIFF
--- a/pages/world-2/alchemy.tsx
+++ b/pages/world-2/alchemy.tsx
@@ -66,9 +66,6 @@ function CauldronDisplay({ cauldron, undevelopedCostsBubbleLevel, barleyBrewVial
     }, [cauldron.bubbles, cauldron.short_name, cauldron.boostLevels, classMultiBonus, undevelopedCostsBubbleLevel, barleyBrewVialLevel, hasAchievement, discountLevel])
 
     function TipContent({ bubble, faceLeft }: { bubble: Bubble, faceLeft: boolean }) {
-        if (bubble.level == 0) {
-            return <></>
-        }
         const materialCosts: Map<Item, number> = bubble.getMaterialCost(cauldronCostLevel, undevelopedCostsBubbleLevel, barleyBrewVialLevel, bargainBubbleLevel, classMultiBubbleLevel, discountLevel, hasAchievement, newMultiBubbleLevel, vialMultiplier);
         return (
             <Box direction="row" align="center" width={{ max: 'medium' }}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15672485/213623658-b3a49351-6e1e-4a73-a647-dfe8ef5ebd41.png)

I don't see why this should be disabled. I always found it annoying not knowing what my next bubble was from the alchemy tab.