### PR TITLE
[Feature] Unobtained stamp hover

### DIFF
--- a/pages/world-1/stamps.tsx
+++ b/pages/world-1/stamps.tsx
@@ -34,7 +34,10 @@ function StampDisplay({ stamp, index, blueFlavPercent, hasBribe }: { stamp: Stam
     function TipContent({ stamp, faceLeft }: { stamp: Stamp, faceLeft: boolean }) {
         if (stamp.level == 0) {
             if (stampItem && stampItem.sources.sources && stampItem.sources.sources.length > 0) {
-                return <ItemSourcesDisplay sources={stampItem.sources} />
+                return <Box>
+                    <Text size="small">Bonus: {stamp.getBonusText()}</Text>
+                    <ItemSourcesDisplay sources={stampItem.sources} />
+                </Box> 
             }
             else {
                 return <Box>Unobtainable</Box>


### PR DESCRIPTION
Shows stamp's bonus (even though it's 0) when you hover over unobtained stamps.
![image](https://user-images.githubusercontent.com/15672485/213843074-fed5eee6-ce42-44ea-9922-a6b293bcc01a.png)

Unobtainable stamps still show as usual
![image](https://user-images.githubusercontent.com/15672485/213843092-1344750f-7902-4bf6-bc22-2133a89e3a8f.png)
