### PR TITLE
[BUGFIX] Printer parsing when old prints exist

### DIFF
--- a/data/domain/printer.tsx
+++ b/data/domain/printer.tsx
@@ -56,11 +56,22 @@ export default function parsePrinter(rawData: any[], charCount: number) {
                 samples.push(new Sample(rawData[5 + (sampleIndex * 2) + (playerIndex * 14)], rawData[6 + (sampleIndex * 2) + (playerIndex * 14)]));
             });
 
+            
             range(0,2).forEach(activeIndex => {
                 const printingItem = rawData[5 + 10 + (activeIndex * 2) + (playerIndex * 14)];
                 const matchingSample = samples.find(sample => sample.item == printingItem);
-                matchingSample!.printingQuantity = rawData[6 + 10 + (activeIndex * 2) + (playerIndex * 14)];
-                matchingSample!.printing += 1;
+                // Old print, without an active sample.
+                const printingQuantity = rawData[6 + 10 + (activeIndex * 2) + (playerIndex * 14)]
+                if (!matchingSample) {
+                    const newSample = new Sample(printingItem, 0);
+                    newSample.printingQuantity = printingQuantity;
+                    newSample.printing += 1;
+                    samples.push(newSample);
+                }
+                else {
+                    matchingSample.printingQuantity = printingQuantity;
+                    matchingSample.printing += 1;
+                }
             })
 
             toReturn.samples[playerIndex] = samples;

--- a/pages/world-3/construction.tsx
+++ b/pages/world-3/construction.tsx
@@ -366,7 +366,8 @@ function SampleBox({ sample, itemData, printing = false }: { sample: Sample, ite
                 {printing && <Text color={sample.inLab == true ? 'blue-3' : ''} size="small">{sample.harriep && <Star size="small" color="gold-1" />} {nFormatter(sample.getSampleQuantity(false))}</Text>}
                 {!printing && <Text color={sample.printing > 0 ? 'green-1' : ''} size="small">{nFormatter(sample.getSampleQuantity(true))}</Text>}
             </Box>
-            {sample.printing > 0 && sample.isOutdatedPrint() &&
+            {/* Show warning on the sample if it's printing and outdated. */}
+            {sample.printing > 0 && !printing && sample.isOutdatedPrint() &&
                 <TipDisplay
                     heading='Active lower than sample'
                     body={<Box><Text>You have a sample of {nFormatter(sample.quantity)} but only printing {nFormatter(sample.printingQuantity)}.</Text><Text>Go update your printing!</Text></Box>}
@@ -492,7 +493,8 @@ function PrinterDisplay() {
                                         <TableCell>
                                             <Box direction="row">
                                                 {
-                                                    samples.map((sample, sampleIndex) => {
+                                                    // We might have samples that are only in the printing slot but already deleted, so only filter for blank and sample quantity bigger then 0)
+                                                    samples.filter(sample => sample.quantity > 0 || sample.item == "Blank").map((sample, sampleIndex) => {
                                                         return (
                                                             <SampleBox key={`sample_${sampleIndex}`} sample={sample} itemData={itemData} printing={false} />
                                                         )


### PR DESCRIPTION
## Overview

The reworked printer was breaking if someone had an active print that didn't match a current sample (basically an old sample that got deleted but still being printed).

Fix that and also fix a bug with the warning since it was showing up on the active slot as well not only the sample slot.