### PR TITLE
[Feature] Add global alert for building construction finished

### DIFF
--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -151,8 +151,8 @@ export class ArcadeFullAlert extends GlobalAlert {
 }
 
 export class ConstructionAlert extends GlobalAlert {
-    constructor(public building: Building) {
-        super(`${building.name} is finished building in construction, go claim.`, AlertType.Construction, building.getImageData())
+    constructor(public count: number) {
+        super(`${count} buildings finished in construction, go claim.`, AlertType.Construction, Construction.sawImageData())
     }
 }
 
@@ -262,11 +262,10 @@ const getGlobalAlerts = (worship: Worship, refinery: Refinery, traps: Trap[][], 
     }
 
     // Construction
-    construction.buildings.map((building) => {
-        if (building.nextLevelUnlocked) {
-            globalAlerts.push(new ConstructionAlert(building));
-        }
-    })
+    const finishedBuildingsCount = construction.buildings.flatMap(building => building).reduce((sum, building) => sum += building.finishedUpgrade ? 1 : 0, 0);
+    if (finishedBuildingsCount > 0){
+        globalAlerts.push(new ConstructionAlert(finishedBuildingsCount));
+    }
 
     return globalAlerts;
 }

--- a/data/domain/buildings.tsx
+++ b/data/domain/buildings.tsx
@@ -19,6 +19,7 @@ export class Building {
 
     level: number = 0;
     nextLevelUnlocked: boolean = false;
+    finishedUpgrade: boolean = false;
     currentXP: number = 0;
 
     constructor(public index: number, data: BuildingModel) {

--- a/data/domain/construction.tsx
+++ b/data/domain/construction.tsx
@@ -56,6 +56,14 @@ export class Construction {
     constructor() {
         this.buildings = Building.fromBase(initBuildingRepo());
     }
+
+    static sawImageData = (): ImageData => {
+        return {
+            location: `ClassIcons49`,
+            height: 50,
+            width: 50
+        }
+    }
 }
 
 export default function parseConstruction(towerData: number[], optionsList: any[]) {
@@ -63,10 +71,13 @@ export default function parseConstruction(towerData: number[], optionsList: any[
     construction.buildings.forEach((building) => {
         building.level = towerData[building.index];
         
+        // Next level is unlocked if the next index for this building is +1.
+        building.nextLevelUnlocked = (building.level + 1) == towerData[building.index + construction.buildings.length];
+
         // Current XP is the last set of indexes, with 12 in the middle of misc info.
         building.currentXP = towerData[building.index + 12 + construction.buildings.length * 2];
 
-        building.nextLevelUnlocked = building.currentXP > building.getBuildCost();
+        building.finishedUpgrade = building.currentXP > building.getBuildCost();
         
     });
     // 55 = building slot 1 = tower number


### PR DESCRIPTION
Just a small addition I had some time to do tonight. Adds a global alert for each completed construction building. 

Images might not be what you want. Any other ideas? They currently look like this:
![image](https://user-images.githubusercontent.com/15672485/237024457-9227b294-7bc4-4075-8ae7-717bca3e131f.png)

I reworked building.nextLevelUnlocked as it looks like the value was always false. Not too sure what the original code was doing as it was just comparing another value in lava spaghetti save data. 