### PR TITLE
[Bugfix] add extra check if finished construction is still in the buildingSlot

### DIFF
--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -264,7 +264,7 @@ const getGlobalAlerts = (worship: Worship, refinery: Refinery, traps: Trap[][], 
     }
 
     // Construction
-    const finishedBuildingsCount = construction.buildings.flatMap(building => building).reduce((sum, building) => sum += building.finishedUpgrade ? 1 : 0, 0);
+    const finishedBuildingsCount = construction.buildings.flatMap(building => building).reduce((sum, building) => sum += building.finishedUpgrade && construction.buildingSlots.includes(building.index) ? 1 : 0, 0);
     if (finishedBuildingsCount > 0){
         globalAlerts.push(new ConstructionAlert(finishedBuildingsCount));
     }


### PR DESCRIPTION
Just realized that the new construction alert stays around even after you "finish" building a building upgrade but don't upgrade it with materials (in the case where you don't have enough materials for example). If the building isn't in the building slot, then the alert for that building doesn't need to happen because the player already "finished" building it. 