### PR TITLE
[Bugfix] include misc value for max level

### DIFF
--- a/data/domain/buildings.tsx
+++ b/data/domain/buildings.tsx
@@ -42,8 +42,7 @@ export class Building {
     }
 
     getBuildCost = (level: number = this.level) => {
-        //misc stores the max possible level after all upgrades (just how wikibot does it)
-        if (level == Math.max(this.maxLvl, this.misc)) {
+        if (level == this.maxLvl) {
             return 0;
         }
         

--- a/data/domain/rift.tsx
+++ b/data/domain/rift.tsx
@@ -193,7 +193,7 @@ export class ConstructionMastery extends RiftBonus {
             case bonusIndex == 3: return this.getRank() > bonusIndex ? 100 : 0;
             case bonusIndex == 4: return this.getRank() > bonusIndex ? 5 * ((this.buildingLevels - 1250) / 10) : 0;
             case bonusIndex == 5: return this.getRank() > bonusIndex ? 100 : 0;
-            case bonusIndex == 5: return this.getRank() > bonusIndex ? 30 : 0;
+            case bonusIndex == 6: return this.getRank() > bonusIndex ? 30 : 0;
             default: return 0;
         }
     }


### PR DESCRIPTION
According to wikibot the misc value is the actual max level for buildings. Not using this was causing trapper drone to report it was max when it wasn't for example. 