### PR TITLE
[Bug] Food lust math was defaulting to 0% instead of 100%

### DIFF
--- a/data/domain/equinox.tsx
+++ b/data/domain/equinox.tsx
@@ -128,13 +128,21 @@ export class FoodLust extends Upgrade {
 
     override getBonus = () => {
         if (this.level == 0 || this.bossesKilled == 0) { 
-            return 0;
+            return 1;
         }
         return Math.max(0.01, Math.pow(0.8, Math.min(this.bossesKilled, this.level)))
     }
 
     isCapped = () => {
+        if (this.level == 0 || this.bossesKilled == 0) { 
+            return false;
+        }
+        
         return this.bossesKilled >= this.level;
+    }
+
+    override getDescription = () => {
+        return this.data.upgrade.split("@")[0].replace("Stacks up to  times", `Stacks up to ${this.level} times`);
     }
 
     override getBonusText = () => {

--- a/pages/world-3/equinox.tsx
+++ b/pages/world-3/equinox.tsx
@@ -82,7 +82,6 @@ function Equinox() {
                                 equinox.upgrades.map((upgrade, index) => {
                                     const foodLust = isFoodLust(upgrade);
                                     const border = foodLust ? { color: 'green-1', size: '1px'} : undefined
-                                    console.log(foodLust, border, upgrade);
                                     return (
                                         <ShadowBox border={border} style={{ opacity: upgrade.unlocked ? 1 : 0.5}} key={index} background="dark-1" margin={{ right: 'small', bottom: 'small' }} pad="medium" gap="medium">
                                             <Text>{upgrade.data.name} ({upgrade.level}/{upgrade.maxLevel})</Text>


### PR DESCRIPTION
## Overview

Silly mistake when food lust isn't leveled to default to 0% which ruined the cooking math.

Also fixed up the alert showing up due to similar reasoning and added the number of possible food lust stacks to the upgrade description.