### PR TITLE
fixed a typo

### DIFF
--- a/data/domain/rift.tsx
+++ b/data/domain/rift.tsx
@@ -170,7 +170,7 @@ export class ConstructionMastery extends RiftBonus {
         "+35_MAX_LV_FOR_TRAPPER_DRONE",
         "+2%_DMG_PER_10_TOT_LV_OVER_750",
         "+100_MAX_LV_FOR_TALENT_LIBRARY",
-        "+5%_BUILD_SPD_PER_TOT_LV_OVER_1250",
+        "+5%_BUILD_SPD_PER_10_TOT_LV_OVER_1250",
         "+100_MAX_LV_FOR_ALL_SHRINES",
         "+30_MAX_LV_FOR_ALL_WIZARD_TOWERS"
     ]


### PR DESCRIPTION
Fixed the typo in rift bonus where it says +5% Build speed per total levels over 1250 instead of per 10 total levels over 1250