### PR TITLE
Now Doot activate only for players that are level 2 or above in divinity

### DIFF
--- a/data/domain/companions.tsx
+++ b/data/domain/companions.tsx
@@ -1,3 +1,4 @@
+import { SkillsIndex } from "./SkillsIndex";
 import { Alchemy } from "./alchemy";
 import { CompanionBase, initCompanionRepo } from "./data/CompanionRepo";
 import { Divinity } from "./divinity";
@@ -58,7 +59,10 @@ export const updateCompanionImpact = (data: Map<string, any>) => {
 
         // And all players are linked to all gods.
         divinity.playerInfo.forEach(player => {
-            player.gods = divinity.gods;
+            // Doot is activated only for characters that are level 2 or above in divinity
+            if (players.find(playerFind => playerFind.playerID == player.playerIndex)?.skills.get(SkillsIndex.Divinity) ?? 0 >= 2) {
+                player.gods = divinity.gods;
+            }
         })
     }
 


### PR DESCRIPTION
The name speaks for itself, set a filter so players need to be at least lv 2 in Divinity to be linked to all gods if Doot companion is owned