### PR TITLE
[Bugfix] Companions logic

### DIFF
--- a/data/domain/companions.tsx
+++ b/data/domain/companions.tsx
@@ -37,7 +37,11 @@ export default function parseCompanions(ownedCompanions: number[]) {
 
     companions.forEach(companion => {
         const editedCompanion = editedCompanions.find(c => c.id === companion.id);
-        companion.owned = editedCompanion ? editedCompanion.owned : ownedCompanions.includes(companion.id);
+        // Check if user edited it before, else default to false.
+        const editState =  editedCompanion ? editedCompanion.owned : false;
+        // We might have an old edit state, so priority for source of truth is currently owned companions
+        // if that one is false, use the edited value.
+        companion.owned = ownedCompanions.includes(companion.id) || editState;
         companion.real = ownedCompanions.includes(companion.id);
     })
 


### PR DESCRIPTION
## Overview

There was a bug with companions editing and stale data. 

Essentially if a user edited companions in the past, it was possible for it to override the `owned` state of the real data leading to a state where users don't get the companions bonus but also can't enable it.

We now prioritise the server data over the localstroage data to avoid such an issue.