### PR TITLE
[UI] Update forge display

### DIFF
--- a/pages/world-1/forge.tsx
+++ b/pages/world-1/forge.tsx
@@ -53,11 +53,11 @@ function Forge() {
     const firstSlotToEmpty = useMemo(() => {
         const forgeSpeed = forge?.upgrades[2].getStat() ?? 0;
         return [...(forge?.slots ?? [])].sort((slot1, slot2) => slot1.getTimeTillEmpty(forgeSpeed) < slot2.getTimeTillEmpty(forgeSpeed) ? -1 : 1)[0];
-    }, [forge])
+    }, [appContext, forge])
 
     const totalCost = useMemo(() => {
         return forge?.upgrades.reduce((sum, upgrade) => sum += upgrade.getMaxCost(), 0) ?? 0;
-    }, [forge])
+    }, [appContext, forge])
 
     useEffect(() => {
         if (appContext) {

--- a/pages/world-1/forge.tsx
+++ b/pages/world-1/forge.tsx
@@ -141,8 +141,8 @@ function Forge() {
                                 const timeTillEmpty = Math.round(slot.ores.count / slot.getOrePerInterval()) * (oreInterval / (4 * slotSpeed))
                                 return (
                                     <ShadowBox background="dark-1" pad={{ vertical: 'medium', horizontal: 'large' }} key={index} margin={{ right: 'medium', bottom: 'medium' }} gap="large" direction="row" fill justify="between" align="center">
-                                        <Box style={{ opacity: slot.brimestone ? 1 : 0.2 }}>
-                                            <IconImage data={{location: 'GemP4', height: 36, width: 36}} />
+                                        <Box style={{ opacity: slot.ores.count > 0 ? 1 : 0.5 }}>
+                                            <IconImage data={{location: slot.brimestone ? 'GemP4' : 'ForgeA', height: 36, width: 36}} />
                                         </Box>
                                         <ForgeItem item={slot.ores} title="Ores" />
                                         <ForgeItem item={slot.oils} title="Oils" />


### PR DESCRIPTION
Now gray out forges if they have no ores in them instead of if Brimstone isn't active for them.

Display the Brimstone icon only for slots that have it bought for it, else display the base forge icon (only the first one, I think displaying the 4 different ones would make it less clean, having only 2 different icons to display feels better to me)