### PR TITLE
[Fix] Worship and Equinox alerts fixed for beginner accounts

### DIFF
--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -286,7 +286,7 @@ const getPlayerAlerts = (player: Player, anvil: AnvilWrapper, playerObols: Obol[
     }
 
     // Cooldown alerts
-    const cooldownTalentIndexes = [32, 130, 370, 490] // Ignoring Charge Syphon (475) for now.
+    const cooldownTalentIndexes = [32, 130, 370, 475, 490]
     cooldownTalentIndexes.forEach(cdTalent => {
         const talent = player.talents.find(talent => talent.skillIndex == cdTalent && talent.level > 0);
         if (talent) {

--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -309,7 +309,7 @@ const getGlobalAlerts = (worship: Worship, refinery: Refinery, traps: Trap[][], 
     const globalAlerts: Alert[] = [];
 
     // Worship
-    if (worship.totalData.overFlowTime <= 0) {
+    if (worship.totalData.maxCharge > 0 && worship.totalData.overFlowTime <= 0 ) {
         globalAlerts.push(new GlobalAlert("Overflowing charge. Go to World 3 -> Worship for more details.", AlertType.Worship, Skilling.getSkillImageData(SkillsIndex.Worship)))
     }
 

--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -349,9 +349,11 @@ const getGlobalAlerts = (worship: Worship, refinery: Refinery, traps: Trap[][], 
     // Equinox Bar Full
     const equinoxBarFull = (equinox.bar.current == equinox.bar.max);
     // Check if there's an unlocked upgrade that can be leveled
-    let canUpgradeSomething = equinox.upgrades.filter(upgrade => upgrade.unlocked == true).some(upgrade => upgrade.level < upgrade.maxLevel)
+    const canUpgradeSomething = equinox.upgrades.filter(upgrade => upgrade.unlocked == true).some(upgrade => upgrade.level < upgrade.maxLevel);
+    // The first upgrade is always unlocked, so to avoid showing the alert for beginner accounts that shouldn't have this, verify if there's at a level in any upgrade
+    const totalLevels = equinox.upgrades.reduce((total: number, upgrade) => {return total + upgrade.level}, 0);
     // If bar is full and have an upgrade that can be improved, display the alert
-    if (equinoxBarFull && canUpgradeSomething) {
+    if (equinoxBarFull && canUpgradeSomething && totalLevels > 0) {
         globalAlerts.push(new EquinoxBarFull());
     }
 

--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -286,7 +286,7 @@ const getPlayerAlerts = (player: Player, anvil: AnvilWrapper, playerObols: Obol[
     }
 
     // Cooldown alerts
-    const cooldownTalentIndexes = [32, 130, 370, 475, 490]
+    const cooldownTalentIndexes = [32, 130, 370, 490] // Ignoring Charge Syphon (475) for now.
     cooldownTalentIndexes.forEach(cdTalent => {
         const talent = player.talents.find(talent => talent.skillIndex == cdTalent && talent.level > 0);
         if (talent) {

--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -281,7 +281,7 @@ const getPlayerAlerts = (player: Player, anvil: AnvilWrapper, playerObols: Obol[
 
     // Worship Alerts
     const playerWorshipInfo = worshipData.playerData[player.playerID];
-    if (playerWorshipInfo && playerWorshipInfo.currentCharge >= playerWorshipInfo.maxCharge) {
+    if (playerWorshipInfo && playerWorshipInfo.maxCharge > 0 && playerWorshipInfo.currentCharge >= playerWorshipInfo.maxCharge) {
         alerts.push(new WorshipAlert(player));
     }
 


### PR DESCRIPTION
Worship global alerts won't be displayed if the account total max charge is at 0

The worship player alert won't be displayed if the player's max charge is at 0 (if no skull is equipped for example)

Equinox bar full alert now do another check to know if it needs to be displayed, read the first commit for more info on that

Also added Charge Syphon into talents that have a displayed alert when off cooldown, if not necessary can be easily rolled back