### PR TITLE
[Fix] Fix Construction Mastery Rift bonus

### DIFF
--- a/data/domain/rift.tsx
+++ b/data/domain/rift.tsx
@@ -207,6 +207,7 @@ export class ConstructionMastery extends RiftBonus {
             case this.buildingLevels < 1250: return 4;
             case this.buildingLevels < 1500: return 5;
             case this.buildingLevels < 2500: return 6;
+            case this.buildingLevels >= 2500: return 7;
             default: return -1;
         }
     }


### PR DESCRIPTION
The switch case used to calculate the rank of this bonus would return -1 once at 2500 total building levels and more

Added another case to prevent this once at or above 2500