### PR TITLE
[Bugfix] Fix issue with people with invalid number of refinery ranks

### DIFF
--- a/data/domain/refinery.tsx
+++ b/data/domain/refinery.tsx
@@ -179,7 +179,7 @@ export class Refinery extends Domain {
 
             [...Array(unlockedSalts)].forEach((_, i) => {
                 const saltIndex = i + 3;
-                if (i > Object.keys(refinery.salts).length) {
+                if (i >= Object.keys(refinery.salts).length) {
                     return;
                 }
                 refinery.salts[`Refinery${i + 1}`].rank = refineryData[saltIndex][1];


### PR DESCRIPTION
## Overview

Sometimes people have weird number of unlocked salts, I put a gurad against it.

It seems my guard wasn't good enough, so fixing it now.