### PR TITLE
[Work] Various bug fixes 2024-05-24

### DIFF
--- a/data/domain/breeding.tsx
+++ b/data/domain/breeding.tsx
@@ -389,7 +389,6 @@ export class Breeding extends Domain {
 
         let baseMath = Math.pow(4 * this.skillLevel + Math.pow(this.skillLevel / 2, 3), 0.85);
         const eggRarity = Math.min(1, Math.max(...this.eggs.map(egg => egg.rarity)));
-        console.log("Pet POWHA!", this.petPowerFromTalent, Math.min(2.1, Math.max(1, this.petPowerFromTalent)))
         baseMath *= Math.min(2.1, Math.max(1, this.petPowerFromTalent)) * (1 + eggRarity / 8);
 
         const maxStat = baseMath * (Math.min(1.2 + this.skillLevel / 12, 4) * Math.pow(2.71828, -10 * 0) + 1);

--- a/data/domain/breeding.tsx
+++ b/data/domain/breeding.tsx
@@ -367,6 +367,9 @@ export class Breeding extends Domain {
     speciesUnlocks: number[] = [];
     skillLevel: number = 0;
     deadCells: number = 0;
+    
+    // Calculated
+    petPowerFromTalent: number = 1;
 
     hasBonus = (bonusNumber: number) => {
         if (bonusNumber > waveReqs.length) {
@@ -386,9 +389,12 @@ export class Breeding extends Domain {
 
         let baseMath = Math.pow(4 * this.skillLevel + Math.pow(this.skillLevel / 2, 3), 0.85);
         const eggRarity = Math.min(1, Math.max(...this.eggs.map(egg => egg.rarity)));
-        const maxRange = Math.max(0.1, 1 - ((eggRarity + 4) / 12) * 0.9);
-        baseMath *= (1 + eggRarity / 8);
+        console.log("Pet POWHA!", this.petPowerFromTalent, Math.min(2.1, Math.max(1, this.petPowerFromTalent)))
+        baseMath *= Math.min(2.1, Math.max(1, this.petPowerFromTalent)) * (1 + eggRarity / 8);
+
         const maxStat = baseMath * (Math.min(1.2 + this.skillLevel / 12, 4) * Math.pow(2.71828, -10 * 0) + 1);
+
+        const maxRange = Math.max(0.1, 1 - ((eggRarity + 4) / 12) * 0.9);
         const minStat = baseMath * (Math.min(1.2 + this.skillLevel / 12, 4) * Math.pow(2.71828, -10 * maxRange) + 1);
         return [minStat, maxStat];
     }
@@ -636,4 +642,15 @@ export const updateAllShinyEffects = (data: Map<string, any>) => {
     cooking.meals.forEach(meal => {
         meal.shinyBonus = breeding.shinyBonuses.find(bonus => bonus.data.index == 20)?.getBonus() ?? 0;;
     });
+}
+
+// This is UI only so sticking it in the end in case we get more crazy level impacts in the future.
+export const updateBeastMasterImpact = (data: Map<string, any>) => {
+    const breeding = data.get("breeding") as Breeding;
+    const players = data.get("players") as Player[];
+
+    const bestBeastmaster = players.reduce((final, player) => final = (player.talents.find(talent => talent.skillIndex == 373)?.level ?? 0) > 0 && player.playerID > final.playerID ? player : final, players[0]);
+    const curvitureTalent = bestBeastmaster.talents.find(talent => talent.skillIndex == 373)?.getBonus() ?? 0;
+
+    breeding.petPowerFromTalent = curvitureTalent;
 }

--- a/data/domain/companions.tsx
+++ b/data/domain/companions.tsx
@@ -64,7 +64,8 @@ export const updateCompanionImpact = (data: Map<string, any>) => {
         // And all players are linked to all gods.
         divinity.playerInfo.forEach(player => {
             // Doot is activated only for characters that are level 2 or above in divinity
-            if (players.find(playerFind => playerFind.playerID == player.playerIndex)?.skills.get(SkillsIndex.Divinity) ?? 0 >= 2) {
+            const divLevel = players.find(playerFind => playerFind.playerID == player.playerIndex)?.skills.get(SkillsIndex.Divinity)?.level ?? 0;
+            if (divLevel >= 2) {
                 player.gods = divinity.gods;
             }
         })

--- a/data/domain/equinox.tsx
+++ b/data/domain/equinox.tsx
@@ -263,7 +263,11 @@ export function updateEquinoxBar(data: Map<string, any>) {
     const equinox = data.get("equinox") as Equinox;
     const alchemy = data.get("alchemy") as Alchemy
     const rawData = data.get("rawData") as Record<string, any>;
-    const bundleInfo = JSON.parse(rawData["BundlesReceived"]) as Record<string, number>;
+    let bundleInfo = undefined;
+    // Make sure we have bundle info, this usually is missing for public profiles.
+    if (rawData["BundlesReceived"] !== undefined) {
+        bundleInfo = JSON.parse(rawData["BundlesReceived"]) as Record<string, number>;
+    }
     const lastUpdated = data.get("lastUpdated") as Date;
 
     const hasBundle = bundleInfo == undefined ? false : bundleInfo.bun_q == 1;

--- a/data/domain/idleonData.tsx
+++ b/data/domain/idleonData.tsx
@@ -26,7 +26,7 @@ import { Dungeons } from './dungeons';
 import { Forge, updateForge } from './forge';
 import { Cooking, updateCooking } from './cooking';
 import { Lab, updateLab } from './lab';
-import { Breeding, updateAllShinyEffects, updateBreeding } from './breeding';
+import { Breeding, updateAllShinyEffects, updateBeastMasterImpact, updateBreeding } from './breeding';
 import { notUndefined } from '../utility';
 import { Sigils, updateSigils, updateSigilsChargeSpeed } from './sigils';
 import { AnvilWrapper, updateAnvil } from './anvil';
@@ -241,6 +241,7 @@ const postPostProcessingMap: Record<string, Function> = {
     "farming": (doc: Cloudsave, accountData: Map<string, any>) => updateFarmingDisplayData(accountData),
     "alerts": (doc: Cloudsave, accountData: Map<string, any>) => updateAlerts(accountData),
     "sigilsChargeSpeed": (doc: Cloudsave, accountData: Map<string, any>) => updateSigilsChargeSpeed(accountData),
+    "petBeastmaster": (doc: Cloudsave, accountData: Map<string, any>) => updateBeastMasterImpact(accountData),
 }
 
 export const updateIdleonData = async (accountData: Map<string, any>, data: Cloudsave, charNames: string[], companions: number[], allItems: Item[], serverVars: Record<string, any>, isStatic: boolean = false) => {

--- a/data/domain/world-6/sneaking.tsx
+++ b/data/domain/world-6/sneaking.tsx
@@ -271,7 +271,7 @@ export class SneakingUpgrade {
     }
 
     static fromBase = (data: NinjaUpgradeBase[]): SneakingUpgrade[] => {
-       return data.map((value) => new SneakingUpgrade(value.index, value.data));
+       return data.filter(value => value.data.name != "").map((value) => new SneakingUpgrade(value.index, value.data));
     }
 }
 

--- a/pages/world-4/cooking.tsx
+++ b/pages/world-4/cooking.tsx
@@ -128,7 +128,7 @@ function KitchenDisplay({ kitchen, cooking, silkRodeChip, starSignEquipped }: { 
     )
 }
 
-function KitchensDisplay({silkRodeChip, starSignEquipped} : {silkRodeChip: boolean, starSignEquipped: boolean}) {
+function KitchensDisplay({ silkRodeChip, starSignEquipped }: { silkRodeChip: boolean, starSignEquipped: boolean }) {
     const [cooking, setCooking] = useState<CookingDomain>();
     const appContext = useContext(AppContext);
 
@@ -221,10 +221,21 @@ function Cooking() {
         return false;
     }, [appContext, cooking])
 
+    const sortByIndex = (meal1: Meal, meal2: Meal) => {
+        if (meal1.level == 0 && meal2.level > 0) {
+            return -1
+        }
+        if (meal2.level == 0 && meal1.level > 0) {
+            return 1
+        }
+
+        return meal1.mealIndex - meal2.mealIndex
+    }
+
     const mealsToShow = useMemo(() => {
         return cooking.meals.filter(meal => meal.timeOptimalSpices.length > 0)
             .sort((meal1, meal2) => {
-                const indexSort = meal1.mealIndex > meal2.mealIndex ? 1 : -1;
+                const indexSort = sortByIndex(meal1, meal2);
 
                 //undiscovered meals get pushed to bottom
                 if (meal1.level == 0) return meal2.level == 0 ? indexSort : 1;
@@ -249,7 +260,7 @@ function Cooking() {
                     }
                     return meal1.getTimeTill(meal1.getMealLevelCost(), starSignEquipped, silkRodeChip, false) > meal2.getTimeTill(meal2.getMealLevelCost(), starSignEquipped, silkRodeChip, false) ? 1 : -1;
                 }
-                
+
                 switch (sort) {
                     case "Level":
                         return meal1.level > meal2.level ? -1 : 1;
@@ -348,7 +359,7 @@ function Cooking() {
                                 label="Gordonius Major Equipped"
                                 onChange={(event) => {
                                     setStarSignEquipped(event.target.checked);
-                                    if(!event.target.checked) {
+                                    if (!event.target.checked) {
                                         setSilkrode(false);
                                     }
                                 }}
@@ -363,9 +374,9 @@ function Cooking() {
                                         <Text size='small'>Looks like you unlocked the Gordonius Major star sign</Text>
                                         {
                                             starSignInfinity ?
-                                            <Text margin={{top:'xsmall'}} size='small'>You always get the star sign bonus thanks to the Infinite Stars Rift bonus</Text>
-                                            :
-                                            <Text margin={{top:'xsmall'}} size='small'>To avoid character checking for a global page, use this checkbox to consider it equipped or not</Text>
+                                                <Text margin={{ top: 'xsmall' }} size='small'>You always get the star sign bonus thanks to the Infinite Stars Rift bonus</Text>
+                                                :
+                                                <Text margin={{ top: 'xsmall' }} size='small'>To avoid character checking for a global page, use this checkbox to consider it equipped or not</Text>
                                         }
                                     </Box>
                                 }
@@ -471,7 +482,7 @@ function Cooking() {
                                                                     <Box direction="row">
                                                                         {
                                                                             meal.chanceOptimalSpices.map((spice, index) => (
-                                                                                <IconImage key={index} data={{
+                                                                                <IconImage style={{ opacity: cooking.spices[spice] > 0 ? 1 : 0.4 }} key={index} data={{
                                                                                     location: `CookingSpice${spice}`,
                                                                                     width: 36,
                                                                                     height: 36
@@ -489,16 +500,16 @@ function Cooking() {
                                                 direction={TipDirection.Down}
                                                 size='small'
                                             >
-                                                <Box direction="row" align="center"  justify="between">
+                                                <Box direction="row" align="center" justify="between">
                                                     <Box direction="row" width="100%" justify="between" pad={!meal.noMealLeftBehindAffected ? { top: 'small' } : undefined}>
-                                                        <Text style={{opacity: meal.level == 0 ? 0.3 : 1}} margin={{ right: 'small' }} size="xsmall">{meal.getBonusText()}</Text>
+                                                        <Text style={{ opacity: meal.level == 0 ? 0.3 : 1 }} margin={{ right: 'small' }} size="xsmall">{meal.getBonusText()}</Text>
                                                         {meal.level > 0 ?
                                                             <Text color={meal.level == meal.maxLevel ? '' : meal.count > meal.getMealLevelCost() ? 'green-1' : 'accent-1'} margin={{ right: 'small' }} size="xsmall">{`${nFormatter(Math.floor(meal.count))}/${nFormatter(Math.ceil(meal.getMealLevelCost()))}`}</Text>
                                                             :
                                                             <Box direction="row" gap="xsmall">
                                                                 {
                                                                     meal.timeOptimalSpices.map((spice, index) => (
-                                                                        <IconImage key={index} data={{
+                                                                        <IconImage key={index} style={{ opacity: cooking.spices[spice] > 0 ? 1 : 0.4 }} data={{
                                                                             location: `CookingSpice${spice}`,
                                                                             width: 36,
                                                                             height: 36
@@ -506,7 +517,7 @@ function Cooking() {
                                                                     ))
                                                                 }
                                                             </Box>
-                                                        }                                                
+                                                        }
                                                     </Box>
                                                     {
                                                         meal.noMealLeftBehindAffected && <Ascending color="Legendary" size="40px" />


### PR DESCRIPTION
## Overview

A bunch of bug fixes based on Discord reports.

* Improved meal sorting to not put "Already at <x>" on top.
* Remove empty sneaking upgrade.
* Fix sneaking images.
* Winner bonuses now are impacted by the new achievements and merits, fixing any impact it had on other aspects.
* Doot no longer incorrectly impacts characters with Divinity level under 2.
* Add atom discount from stamp.
* Add Beast master impact on pet power to min/max stat range.
* Low opacity for meal discovery if you don't have the needed spices