### PR TITLE
[Work] Make certain links always direct to main domain

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -8,7 +8,7 @@ import {
     return (
       <Box pad="large" align="center" fill>
         <Heading level='1'>404 - Page Not Found</Heading>
-        <Link href="/">
+        <Link href="https://www.idleonefficiency.com/">
           Home Page
         </Link>
       </Box>

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -34,7 +34,7 @@ export const FooterComponent = () => {
                     <Box align="center" pad="small">
                         <Text size="12px" color="grey-2">|</Text>
                     </Box>
-                    <IconLink icon={Icon} href="/privacy-policy" text="Privacy Policy" target="_self" />
+                    <IconLink icon={Icon} href="https://www.idleonefficiency.com/privacy-policy" text="Privacy Policy" target="_self" />
                     <Box align="center" pad="small">
                         <Text size="12px" color="grey-2">|</Text>
                     </Box>

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -12,7 +12,7 @@ export const HeaderComponent = () => {
     return (
         <Header background="dark-1" height="56px" border={{ color: "white-1", side: "bottom" }}>
             <Box width={{ max: '1440px' }} margin={{ left: 'auto', right: 'auto' }} direction="row" justify='between' align="center" pad="small" fill>
-                <Link passHref href={"/"} legacyBehavior>
+                <Link passHref href={"https://www.idleonefficiency.com/"} legacyBehavior>
                     <Box>
                         <Image alt="Logo" src="/logo.svg" height={21} width={171} />
                     </Box>

--- a/components/header/profile.tsx
+++ b/components/header/profile.tsx
@@ -64,7 +64,7 @@ export const Profile = () => {
                     onClick={() => setProfileDropDownOpen(true)}
                     dropContent={
                         <Box width="small" border={{ color: 'grey-1' }} round="small">
-                            {dataStatus == DataStatus.LiveData && <Link href={'/profile/upload'} legacyBehavior>
+                            {dataStatus == DataStatus.LiveData && <Link href={'https://www.idleonefficiency.com/profile/upload'} legacyBehavior>
                                 <Button onClick={() => setProfileDropDownOpen(false)} hoverIndicator={{ color: 'brand', size: 'large' }} color="accent-2">
                                     <Box align="center" pad="small">Public Profile</Box>
                                 </Button>


### PR DESCRIPTION
## Overview

Some links (like privacy policy or profile upload) don't make sense as "relative" link to the sub-domains (i.e. anchored to the player profile domain).

So it's better to force these to point always to the main official domain.