### PR TITLE
[Bugfix] Stamp grid and calculator for newer accounts

### DIFF
--- a/components/world-1/stampTableView.tsx
+++ b/components/world-1/stampTableView.tsx
@@ -1,13 +1,13 @@
 import {
     Data,
     DataFilter,
-    DataFilters, 
-    DataSearch, 
-    DataSummary, 
-    DataTable, 
-    Toolbar, 
-    Select, 
-    CheckBox, 
+    DataFilters,
+    DataSearch,
+    DataSummary,
+    DataTable,
+    Toolbar,
+    Select,
+    CheckBox,
     DataSort
 } from "grommet";
 
@@ -68,19 +68,23 @@ function StampsTableView({ stamps }: { stamps: Stamp[] }) {
     const collider = theData.get("collider") as AtomCollider;
     const allItems = theData.get("itemsData") as Item[];
 
+    const gildedUnlocked = stamps[0]?.gildedAvailable ?? false;
     // Initialize state with current values from the first stamp
     const [selectedAtomDiscount, setSelectedAtomDiscount] = useState<number>(collider.atoms[0].getBonus());
-    const [useGilded, setUseGilded] = useState<boolean>(stamps[0]?.gildedAvailable && stamps[0]?.gildedCount > 0);
+    const [useGilded, setUseGilded] = useState<boolean>(gildedUnlocked && stamps[0]?.gildedCount > 0);
 
     // Generate atom discount options
     const discountIncrement = collider.atoms[0].level * collider.atoms[0].data.bonusPerLv;
     const atomDiscountOptions: number[] = [];
-    for (let discount = 0; discount <= 90; discount += discountIncrement) {
-        atomDiscountOptions.push(discount);
-    }
-    // Ensure 90 is always included if it's not already (in case of non-divisible increments)
-    if (!atomDiscountOptions.includes(90)) {
-        atomDiscountOptions.push(90);
+    // We only have options if increment > 0, i.e. hydrogen is unlocked.
+    if (discountIncrement > 0) {
+        for (let discount = 0; discount <= 90; discount += discountIncrement) {
+            atomDiscountOptions.push(discount);
+        }
+        // Ensure 90 is always included if it's not already (in case of non-divisible increments)
+        if (!atomDiscountOptions.includes(90)) {
+            atomDiscountOptions.push(90);
+        }
     }
 
     const columns = [
@@ -328,27 +332,31 @@ function StampsTableView({ stamps }: { stamps: Stamp[] }) {
                 <Toolbar>
                     <DataSearch responsive />
                     <Box direction="row" gap="medium" margin={{ bottom: 'medium' }} align="center">
-                        <Box direction="row" gap="small" align="center">
-                            <Text size="small">Atom Discount:</Text>
-                            <Select
-                                options={atomDiscountOptions.map(value => ({
-                                    label: `${value}%`,
-                                    value: value
-                                }))}
-                                labelKey="label"
-                                valueKey={{ key: "value", reduce: true }}
-                                value={selectedAtomDiscount}
-                                onChange={({ value }) => setSelectedAtomDiscount(value)}
-                                inert={false}
-                            />
-                        </Box>
-                        <Box direction="row" gap="small" align="center">
-                            <CheckBox
-                                checked={useGilded}
+                        {atomDiscountOptions.length > 0 &&
+                            <Box direction="row" gap="small" align="center">
+                                <Text size="small">Atom Discount:</Text>
+                                <Select
+                                    options={atomDiscountOptions.map(value => ({
+                                        label: `${value}%`,
+                                        value: value
+                                    }))}
+                                    labelKey="label"
+                                    valueKey={{ key: "value", reduce: true }}
+                                    value={selectedAtomDiscount}
+                                    onChange={({ value }) => setSelectedAtomDiscount(value)}
+                                    inert={false}
+                                />
+                            </Box>
+                        }
+                        {gildedUnlocked &&
+                            <Box direction="row" gap="small" align="center">
+                                <CheckBox
+                                    checked={useGilded}
                                 label={<Text size="small">Use Gilded</Text>}
                                 onChange={(event) => setUseGilded(event.target.checked)}
-                            />
-                        </Box>
+                                />
+                            </Box>
+                        }
                     </Box>
                     <DataFilters layer>
                         <DataFilter property="type" />

--- a/data/domain/alerts.tsx
+++ b/data/domain/alerts.tsx
@@ -480,13 +480,15 @@ const getGlobalAlerts = (worship: Worship, refinery: Refinery, traps: Trap[][], 
     }
     
     // Can buy a familiar for Summoning (in case cost reset for example)
-    const familiarUpgrade = summoning.summonUpgrades.find(bonus => bonus.index == 2)!;
-    const familiarUpgradeUnlocked = familiarUpgrade.unlocked;
-    const canBuyFamiliar = familiarUpgrade.nextLevelCost() < (summoning.summonEssences.find(essence => essence.color == SummonEssenceColor.White)?.quantity ?? 0);
-    const maxedFamiliarUpgrade = familiarUpgrade.level == familiarUpgrade.data.maxLvl;
-    // If the upgrade is unlocked, can afford a level, and not already maxed, display the alert
-    if (familiarUpgradeUnlocked && canBuyFamiliar && !maxedFamiliarUpgrade) {
-        globalAlerts.push(new CanBuySummoningFamiliar());
+    const familiarUpgrade = summoning.summonUpgrades.find(bonus => bonus.index == 2);
+    if (familiarUpgrade) {
+        const familiarUpgradeUnlocked = familiarUpgrade.unlocked;
+        const canBuyFamiliar = familiarUpgrade.nextLevelCost() < (summoning.summonEssences.find(essence => essence.color == SummonEssenceColor.White)?.quantity ?? 0);
+        const maxedFamiliarUpgrade = familiarUpgrade.level == familiarUpgrade.data.maxLvl;
+        // If the upgrade is unlocked, can afford a level, and not already maxed, display the alert
+        if (familiarUpgradeUnlocked && canBuyFamiliar && !maxedFamiliarUpgrade) {
+            globalAlerts.push(new CanBuySummoningFamiliar());
+        }
     }
 
     return globalAlerts;

--- a/data/domain/world-1/stamps.tsx
+++ b/data/domain/world-1/stamps.tsx
@@ -368,7 +368,7 @@ export function updateStampMaxCarry(data: Map<string, any>) {
         stamp.calculateCostForNextTiers(dailyAtomDiscountIncrease);
         
         // Calculate all common upgrade scenarios
-        stamp.upgradeCalculator.calculateAllScenarios(dailyAtomDiscountIncrease);
+        stamp.upgradeCalculator.calculateAllScenarios(dailyAtomDiscountIncrease, stamp.gildedAvailable ?? false);
 
         if (stamp.level > 0 && stampMatBagType != undefined) { // if stamp is actually unlocked and material used fits the carry cap maths.
             // If max level, we need to upgrade with mats


### PR DESCRIPTION
## Overview

As usual, I didn't test things properly for newer players.

Players without hydrogen (discount increment == 0) would end up in an inifnite loop which will break parsing / the page.

Added handling for discount being 0% and gilded being only false both in the data side and the UI side.

## Notes

Also realized we have a bug for accounts that don't have summoning data with the familiar alert so fixed that while I was there.