### PR TITLE
[Bugfix] Prevent new jewels from breaking the site

### DIFF
--- a/data/domain/lab.tsx
+++ b/data/domain/lab.tsx
@@ -381,7 +381,7 @@ export class Lab extends Domain {
         }
 
         labData[14].forEach((value, index) => {
-            if (value == 1) {
+            if (value == 1 && lab.jewels.length > index) {
                 lab.jewels[index].available = true;
             }
         })

--- a/data/domain/talents.tsx
+++ b/data/domain/talents.tsx
@@ -116,7 +116,7 @@ export enum ClassIndex {
     Elemental_Sorcerer = 34,
     Spiritual_Monk = 35,
     Bubonic_Conjuror = 36,
-    Arcane_Cultist = 37
+    Arcane_Cultist = 40
 }
 
 export const ClassTalentMap: Record<ClassIndex, string[]> = {
@@ -146,7 +146,7 @@ export const ClassTalentMap: Record<ClassIndex, string[]> = {
     [ClassIndex.Elemental_Sorcerer]: ["Savvy Basics", "Mage", "Wizard", "Elemental Sorcerer"],
     [ClassIndex.Spiritual_Monk]: [],
     [ClassIndex.Bubonic_Conjuror]: ["Savvy Basics", "Mage", "Shaman", "Bubonic Conjuror"],
-    [ClassIndex.Arcane_Cultist]: [],
+    [ClassIndex.Arcane_Cultist]: ["Savvy Basics", "Mage", "Shaman", "Bubonic Conjuror", "Arcane Cultist"],
 }
 
 const allTalents = initTalentTreeRepo();


### PR DESCRIPTION
## Overview

The current code can break if new jewels are added and user obtains them.

This bugfix is simply adding a safety measure to prevent that.