### PR TITLE
[Bugfix] Efficiency calculations are off by one

### DIFF
--- a/app/login/steam/page.tsx
+++ b/app/login/steam/page.tsx
@@ -32,9 +32,6 @@ function SteamLogin() {
             }
         }
         
-        console.log('OpenID Parameters:', openIdParams)
-        console.log('Steam ID:', steamId)
-        
         setSteamData(openIdParams)
         setLoading(false)
         getFirebaseToken(openIdParams)
@@ -60,7 +57,6 @@ function SteamLogin() {
             }
         };
         
-        console.log("Request payload:", requestData);
 
         try {
             const response = await fetch(target_function, {
@@ -76,7 +72,6 @@ function SteamLogin() {
             }
 
             const data = await response.json();
-            console.log("Response data:", data);
             return data;
         } catch (error) {
             console.error("Error fetching Firebase token:", error);

--- a/components/account/grimoireDisplay.tsx
+++ b/components/account/grimoireDisplay.tsx
@@ -49,7 +49,7 @@ function EfficiencySection() {
             showConsolidation: true
         },
         {
-            id: 'Cheapest Path',
+            id: 'Unlock Path',
             label: 'Unlock Path',
             showCountSelector: false,
             showConsolidation: true
@@ -61,7 +61,7 @@ function EfficiencySection() {
         'Wraith Damage': {
             valueHeader: "Damage +",
             valueColor: "accent-2",
-            formatValue: (value: number) => `${value.toFixed(2)}`,
+            formatValue: (value: number) => `${nFormatter(value, "CommaNotation")}`,
             noResultsText: "No efficient damage upgrades available (insufficient bones, all upgrades maxed, or all locked)"
         },
         'Bone Drop Rate': {
@@ -70,7 +70,7 @@ function EfficiencySection() {
             formatValue: (value: number) => `${value.toFixed(4)}x`,
             noResultsText: "No efficient bone drop upgrades available (insufficient bones, all upgrades maxed, or all locked)"
         },
-        "Cheapest Path": {
+        "Unlock Path": {
             valueHeader: '',
             valueColor: 'accent-2',
             formatValue: (value: number) => ``,
@@ -82,7 +82,7 @@ function EfficiencySection() {
     const efficiencyResults = new Map([
         ['Wraith Damage', grimoire.efficiencyResults.get('Wraith Damage') || { goal: "", pathUpgrades: [], totalValue: 0, resourceCosts: {} }],
         ['Bone Drop Rate', grimoire.efficiencyResults.get('Bone Drop Rate') || { goal: "", pathUpgrades: [], totalValue: 0, resourceCosts: {} }],
-        ['Cheapest Path', grimoire.efficiencyResults.get('Cheapest Path') || { goal: "", pathUpgrades: [], totalValue: 0, resourceCosts: {} }]
+        ['Unlock Path', grimoire.efficiencyResults.get('Cheapest Path') || { goal: "", pathUpgrades: [], totalValue: 0, resourceCosts: {} }]
     ]);
 
     return (

--- a/components/account/shared/EfficiencyAnalysis.tsx
+++ b/components/account/shared/EfficiencyAnalysis.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState, ReactNode, useMemo } from 'react';
 import { Box, Text } from 'grommet';
 import { EfficiencyControls, OptimizationType } from './EfficiencyControls';
 import { EfficiencyDisplay } from './EfficiencyDisplay';
@@ -39,6 +39,10 @@ export function EfficiencyAnalysis({
     const currentEfficiencyData = efficiencyResults.get(selectedOptimization);
     const currentValueConfig = valueConfigs[selectedOptimization];
     const currentOptimization = optimizationTypes.find(opt => opt.id === selectedOptimization);
+    
+    const sortByResource = useMemo(() => {
+        return selectedOptimization === "Unlock Path";
+    }, [selectedOptimization]);
 
     // Early return if no efficiency data
     if (!currentEfficiencyData || !currentValueConfig) {
@@ -94,6 +98,7 @@ export function EfficiencyAnalysis({
                     formatValue={currentValueConfig.formatValue}
                     noResultsText={currentValueConfig.noResultsText}
                     consolidateUpgrades={consolidateUpgrades}
+                    sortByResource={sortByResource}
                 />
             </Box>
         </ShadowBox>

--- a/components/account/tesseractDisplay.tsx
+++ b/components/account/tesseractDisplay.tsx
@@ -42,27 +42,27 @@ export function TesseractDisplay() {
 
     // Define optimization types for efficiency analysis
     const optimizationTypes = [
-        { id: 'Cheapest Path', label: 'Cheapest Path', showCountSelector: false, showConsolidation: true },
+        { id: 'Unlock Path', label: 'Unlock Path', showCountSelector: false, showConsolidation: true },
         { id: 'Arcane Damage', label: 'Arcane Damage', showCountSelector: true, showConsolidation: true },
         { id: 'Tachyon Drop Rate', label: 'Tachyon Drop Rate', showCountSelector: true, showConsolidation: true }
     ];
 
     // Configuration for value display
     const valueConfigs = {
-        "Cheapest Path": {
+        "Unlock Path": {
             valueHeader: '',
             valueColor: 'accent-2',
             formatValue: (value: number) => ``,
             noResultsText: 'No efficient upgrades available'
         },
-        'Arcane Damage': { valueHeader: 'Damage +', valueColor: 'accent-2', formatValue: (value: number) => `${nFormatter(value)}`, noResultsText: 'No efficient damage upgrades available' },
+        'Arcane Damage': { valueHeader: 'Damage +', valueColor: 'accent-2', formatValue: (value: number) => `${nFormatter(value, "CommaNotation")}`, noResultsText: 'No efficient damage upgrades available' },
         'Tachyon Drop Rate': { valueHeader: 'Multiplier +', valueColor: 'accent-2', formatValue: (value: number) => `${(value).toFixed(4)}x`, noResultsText: 'No efficient tachyon drop upgrades available' }
     };
 
     // Create efficiency results map
     const defaultPathInfo = { goal: "", pathUpgrades: [], totalValue: 0, resourceCosts: {} };
     const efficiencyResults = new Map([
-        ['Cheapest Path', tesseract.efficiencyResults.get('Cheapest Path') || defaultPathInfo],
+        ['Unlock Path', tesseract.efficiencyResults.get('Cheapest Path') || defaultPathInfo],
         ['Arcane Damage', tesseract.efficiencyResults.get('Arcane Damage') || defaultPathInfo],
         ['Tachyon Drop Rate', tesseract.efficiencyResults.get('Tachyon Drop Rate') || defaultPathInfo]
     ]);

--- a/lib/efficiencyEngine/efficiencyEngine.tsx
+++ b/lib/efficiencyEngine/efficiencyEngine.tsx
@@ -158,7 +158,6 @@ export class EfficiencyEngine<T extends EfficiencyDomain> {
             if (bestUpgrade) {
                 // Create a snapshot of the upgrade state for display (showing the level it will be after purchase)
                 const upgradeSnapshot = bestUpgrade.copyUpgrade();
-                upgradeSnapshot.setLevel(upgradeSnapshot.getLevel() + 1); // Show the level after purchase
 
                 result.pathUpgrades.push({
                     upgrade: upgradeSnapshot,


### PR DESCRIPTION
## Overview

The efficiency calculations snapshots were off by one (showing purchase 18->20 when your upgrade is actually level 17).

At the same time doing some visual improvements requested by users.