### PR TITLE
[Bugfix] Player sorting and typo in mining capacity

### DIFF
--- a/data/domain/capacity.tsx
+++ b/data/domain/capacity.tsx
@@ -213,7 +213,7 @@ const capacityToBagMapping: Record<string, Record<number, string>> = {
         5000: "MaxCapBagMi7",
         10000: "MaxCapBagMi8",
         20000: "MaxCapBagMi9",
-        25000: "MaxCapBagMi110",
+        25000: "MaxCapBagMi10",
         30000: "MaxCapBagMi11",
         250000: "MaxCapBag",
         500000: "MaxCapBag",

--- a/data/domain/idleonData.tsx
+++ b/data/domain/idleonData.tsx
@@ -1,7 +1,7 @@
 import { Traps } from './traps';
 import { Stamps, updateStampMaxCarry, updateStamps } from './world-1/stamps';
 import { Statues, updateStatueBonuses } from './statues';
-import { Players, playerExtraCalculations, updatePlayerDeathnote, updatePlayerStarSigns, updatePlayerTalentLevelExceptESBonus, updatePlayers, updatePlayerTalentLevelESBonus, updatePlayerTalentPoints } from './player';
+import { Players, playerExtraCalculations, updatePlayerDeathnote, updatePlayerStarSigns, updatePlayerTalentLevelExceptESBonus, updatePlayers, updatePlayerTalentLevelESBonus, updatePlayerTalentPoints, Player } from './player';
 import { Alchemy, updateAlchemy, updateAlchemySlabBubbles, updateAlchemyTomeBubbles } from './alchemy';
 import { Bribes } from './bribes';
 import { GemStore } from './gemPurchases';
@@ -354,8 +354,9 @@ export const updateIdleonData = (accountData: Map<string, any>, data: Cloudsave,
     })
 
     // I sometimes forget that sorting has implication, fix sorting in the end incase I screwed something up in the post processing functions.
-    // const players = accountData.get("players") as Player[];
-    // players.sort((playera, playerb) => playera.playerID > playerb.playerID ? 1 : -1);
+    // TODO: Need to think of a safe way to handle this longer term.
+    const players = accountData.get("players") as Player[];
+    players.sort((playera, playerb) => playera.playerID > playerb.playerID ? 1 : -1);
 
     const newData = new IdleonData(accountData, lastUpdated);
 

--- a/data/domain/tesseract.tsx
+++ b/data/domain/tesseract.tsx
@@ -743,7 +743,7 @@ export const updateTesseractEfficiency = (accountData: Map<string, any>) => {
     if (tesseract && players) {
         try {
             // Find best Arcane Cultist
-            const arcaneCultist = players.sort((a, b) => b.level - a.level).find(p => p.classId === 40);
+            const arcaneCultist = players.slice().sort((a, b) => b.level - a.level).find(p => p.classId === 40);
             if (arcaneCultist) {
                 tesseract.bestArcaneCultist = arcaneCultist;
                 


### PR DESCRIPTION
## Overview

I screwed up by doing `players.sort` again. Fixing it to have a `slice` and restoring the "safety" sort at the end of data handling.

Also fixing a tiny bug / typo in the mining capacity bag name