### PR TITLE
[Bugfix] Fix inconsistent formatting for elite class numbers

### DIFF
--- a/components/account/compassDisplay.tsx
+++ b/components/account/compassDisplay.tsx
@@ -220,7 +220,7 @@ function EfficiencySection() {
             showConsolidation: true,
             currentValues: [{
                 label: "Current Tempest Accuracy",
-                value: `${compass.currentTempestAccuracy.toFixed(2)}`
+                value: nFormatter(compass.currentTempestAccuracy, "CommaNotation")
             }]
         },
         {
@@ -230,7 +230,7 @@ function EfficiencySection() {
             showConsolidation: true,
             currentValues: [{
                 label: "Current Tempest Defense",
-                value: `${compass.currentTempestDefense.toFixed(2)}`
+                value: nFormatter(compass.currentTempestDefense, "CommaNotation")
             }]
         }
     ];
@@ -240,25 +240,25 @@ function EfficiencySection() {
         'Tempest Damage': {
             valueHeader: "Damage +",
             valueColor: "accent-1",
-            formatValue: (value: number) => `${value.toFixed(2)}`,
+            formatValue: (value: number) => nFormatter(value, "CommaNotation"),
             noResultsText: "No efficient damage upgrades available (insufficient dust, all upgrades maxed, or all locked)"
         },
         'Dust Multiplier': {
             valueHeader: "Multiplier +",
             valueColor: "accent-2",
-            formatValue: (value: number) => `+${value.toFixed(4)}x`,
+            formatValue: (value: number) => `+${value.toFixed(2)}x`,
             noResultsText: "No efficient dust upgrades available (insufficient dust, all upgrades maxed, or all locked)"
         },
         'Tempest Accuracy': {
             valueHeader: "Accuracy +",
             valueColor: "accent-3",
-            formatValue: (value: number) => `+${value.toFixed(2)}`,
+            formatValue: (value: number) => `+${nFormatter(value, "CommaNotation")}`,
             noResultsText: "No efficient accuracy upgrades available (insufficient dust, all upgrades maxed, or all locked)"
         },
         'Tempest Defense': {
             valueHeader: "Defense +",
             valueColor: "accent-4",
-            formatValue: (value: number) => `+${value.toFixed(2)}`,
+            formatValue: (value: number) => `+${nFormatter(value, "CommaNotation")}`,
             noResultsText: "No efficient defense upgrades available (insufficient dust, all upgrades maxed, or all locked)"
         }
     };

--- a/components/account/grimoireDisplay.tsx
+++ b/components/account/grimoireDisplay.tsx
@@ -110,7 +110,7 @@ function EfficiencySection() {
         'Bone Drop Rate': {
             valueHeader: "Multiplier +",
             valueColor: "accent-2",
-            formatValue: (value: number) => `${value.toFixed(4)}x`,
+            formatValue: (value: number) => `${value.toFixed(2)}x`,
             noResultsText: "No efficient bone drop upgrades available (insufficient bones, all upgrades maxed, or all locked)"
         },
         'Wraith Accuracy': {

--- a/components/account/tesseractDisplay.tsx
+++ b/components/account/tesseractDisplay.tsx
@@ -114,7 +114,7 @@ export function TesseractDisplay() {
             noResultsText: 'No efficient upgrades available'
         },
         'Arcane Damage': { valueHeader: 'Damage +', valueColor: 'accent-2', formatValue: (value: number) => `${nFormatter(value, "CommaNotation")}`, noResultsText: 'No efficient damage upgrades available' },
-        'Tachyon Drop Rate': { valueHeader: 'Multiplier +', valueColor: 'accent-2', formatValue: (value: number) => `${(value).toFixed(4)}x`, noResultsText: 'No efficient tachyon drop upgrades available' },
+        'Tachyon Drop Rate': { valueHeader: 'Multiplier +', valueColor: 'accent-2', formatValue: (value: number) => `${(value).toFixed(2)}x`, noResultsText: 'No efficient tachyon drop upgrades available' },
         'Arcane Accuracy': { valueHeader: 'Accuracy +', valueColor: 'accent-2', formatValue: (value: number) => `${nFormatter(value, "CommaNotation")}`, noResultsText: 'No efficient accuracy upgrades available' },
         'Arcane Defense': { valueHeader: 'Defense +', valueColor: 'accent-2', formatValue: (value: number) => `${nFormatter(value, "CommaNotation")}`, noResultsText: 'No efficient defense upgrades available' }
     };


### PR DESCRIPTION
## Overview

I missed formatting the damage/accuracy/defence numbers for Compass page. Also made other numbers slightly more consistent.