### PR TITLE
[Bugfix] Add some defensive programming for new checks

### DIFF
--- a/data/domain/alchemy.tsx
+++ b/data/domain/alchemy.tsx
@@ -758,13 +758,15 @@ export class Alchemy extends Domain {
 
         // Mark bubbles that are prismatic
         const prismaticBubbles = optionList[384] as string;
+        if (prismaticBubbles && prismaticBubbles.length > 0) {
         alchemy.cauldrons.flatMap(cauldron => cauldron.bubbles).forEach(bubble => {
             // I don't think the comma in the end really matters, but it's here
             // to match the game code.
             if (prismaticBubbles.includes(`${bubble.getBubbleIdentifier()},`)) {
                 bubble.prismatic = true;
-            }
-        })
+                }
+            })
+        }
     }
 }
 

--- a/data/domain/arcade.tsx
+++ b/data/domain/arcade.tsx
@@ -177,9 +177,11 @@ export class Arcade extends Domain {
         arcade.goldBalls = optionList[75] as number || 0;    
 
         // Check for companion 27 (reindeer) - "2.00x Gold Ball Shop Bonuses"
-        arcade.bonuses.forEach(bonus => {
-            bonus.hasCompanion27 = ownedCompanions.includes(27);
-        });
+        if (ownedCompanions && ownedCompanions.length > 0) {
+            arcade.bonuses.forEach(bonus => {
+                bonus.hasCompanion27 = ownedCompanions.includes(27);
+            });
+        };
     }
 }
 

--- a/data/domain/misc/equipmentSets.tsx
+++ b/data/domain/misc/equipmentSets.tsx
@@ -66,9 +66,12 @@ export class EquipmentSets extends Domain {
         equipmentSets.unlocked = smithyUnlocked == 1;
         equipmentSets.permanentlyActive = isSmithyUnlocked;
         equipmentSets.daysPassed = days;
-        equipmentSets.equipmentSets.forEach(set => {
-            set.unlocked = unlockedSets.includes(set.data.name);
-        });
+        // If user unlocked sets, set the unlocked status for each set
+        if (unlockedSets && unlockedSets.length > 0) {
+            equipmentSets.equipmentSets.forEach(set => {
+                set.unlocked = unlockedSets.includes(set.data.name);
+            });
+        }
     }
 
     getSetBonus = (setName: string, player?: Player, raw: boolean = false) => {


### PR DESCRIPTION
## Overview

A user reported an issue with `includes` not being a function after the latest update.

<img width="1919" height="920" alt="image" src="https://github.com/user-attachments/assets/cb8dd9a6-3272-43a1-9f63-1e84e0403c66" />

## Solution

I've located any new `includes` function and added defensive checks. Lava likes to set things to `null` sometimes so it's possible it's causing an issue. 
