### PR TITLE
Include alchemy bubble bonus in 'maxTraps' calculation

### DIFF
--- a/app/world-3/trapping/content.tsx
+++ b/app/world-3/trapping/content.tsx
@@ -68,14 +68,11 @@ function PlayerTraps(props: PlayerTrapProps) {
                                             <Box>
                                                 <Text>Trap Type: {TrapSet[trap.trapType]}</Text>
                                                 <Text>Original Duration: {formatTime(trap.trapDuration)?.replace("in ", "") ?? ""}</Text>
-                                                {
-                                                    trap.getBenefits().map((bonus, index) => (
-                                                        <Box key={`bonus_${index}`}>
-                                                            <Text>{bonus}</Text>
-                                                        </Box>
-                                                    ))
-                                                }
-
+                                                <Box direction="row">
+                                                    <Text>
+                                                        Bonuses: {trap.getBenefits().join(" | ")}    
+                                                    </Text>
+                                                </Box>
                                             </Box>
                                         }
                                         size='medium'
@@ -102,6 +99,8 @@ function Traps() {
     const playerTraps = theData.get("traps") as Trap[][];
     const playerNames = theData.get("playerNames") as string[];
     const playerData = theData.get("players") as Player[];
+    const alchemy = theData.get("alchemy");
+    const hasAlchemyExtraTrap = (alchemy?.cauldrons?.[1]?.bubbles?.[11]?.level ?? 0) > 0.5;
 
     return (
         <Box>
@@ -120,7 +119,7 @@ function Traps() {
                             playerTraps.filter(x => playerNames[x[0]?.playerID] != undefined).map((trapsData, index) => {
                                 const boxSet = playerData?.find((player) => player.playerID == trapsData[0]?.playerID)?.gear.tools.find((tool) => tool?.type == "Trap Box Set");
                                 const skillLevel = playerData?.find((player) => player.playerID == trapsData[0]?.playerID)?.skills.get(SkillsIndex.Trapping)?.level;
-                                const maxTraps = Trap.getMaxTraps(boxSet);
+                                const maxTraps = Trap.getMaxTraps(boxSet, hasAlchemyExtraTrap);
                                 return (
                                     <TableRow key={`traps_${index}`}>
                                         <TableCell>
@@ -137,7 +136,7 @@ function Traps() {
                                             }
                                         </TableCell>
                                         <TableCell>
-                                            <PlayerTraps traps={trapsData} maxTraps={maxTraps + 1} />
+                                            <PlayerTraps traps={trapsData} maxTraps={maxTraps} />
                                         </TableCell>
                                     </TableRow>
                                 )

--- a/data/domain/world-3/traps.tsx
+++ b/data/domain/world-3/traps.tsx
@@ -109,6 +109,9 @@ export class Trap {
                 case "TrapBoxSet6": return 6;
                 case "TrapBoxSet7": return 7;
                 case "TrapBoxSet8": return 7;
+                case "TrapBoxSet9": return 7;
+                case "TrapBoxSet10": return 7;
+                case "TrapBoxSet11": return 7;
                 default: return 1;
             }
         })();

--- a/data/domain/world-3/traps.tsx
+++ b/data/domain/world-3/traps.tsx
@@ -13,52 +13,56 @@ export enum TrapSet {
     Royal = 6,
 }
 
-const trapBoxInfo = [
+type TrapBoxInfo = 
+    | { duration: number; qty: number; exp: number}
+    | { duration: number; qty: number; shiny: number}
+
+const trapBoxInfo: TrapBoxInfo[][] = [
     [
-        [1200, 1, 1, 0],
-        [3600, 2, 2, 0],
-        [28800, 10, 8, 0],
-        [72e3, 20, 15, 0]
+        {duration: 1200, qty: 1, exp: 1},
+        {duration: 3600, qty: 2, exp: 2},
+        {duration: 28800, qty: 10, exp: 8},
+        {duration: 72e3, qty: 20, exp: 15}
     ],
     [
-        [1200, 1, 2, 1],
-        [3600, 2, 4, 1],
-        [28800, 10, 16, 1],
-        [72e3, 20, 30, 1],
-        [144e3, 35, 50, 1]
+        {duration: 1200, qty: 1, shiny: 2},
+        {duration: 3600, qty: 2, shiny: 4},
+        {duration: 28800, qty: 10, shiny: 16},
+        {duration: 72e3, qty: 20, shiny: 30},
+        {duration: 144e3, qty: 35, shiny: 50}
     ],
     [
-        [10800, 5, 5, 0],
-        [216e3, 50, 40, 0],
-        [432e3, 100, 80, 0],
-        [432e3, 200, 0, 0],
-        [432e3, 0, 200, 0]
+        {duration: 10800, qty: 5, exp: 5},
+        {duration: 216e3, qty: 50, exp: 40},
+        {duration: 432e3, qty: 100, exp: 80},
+        {duration: 432e3, qty: 200, exp: 0},
+        {duration: 432e3, qty: 0, exp: 200}
     ],
     [
-        [28800, 0, 40, 0],
-        [72e3, 0, 75, 0],
-        [158e3, 0, 120, 0],
-        [518e3, 0, 350, 0]
+        {duration: 28800, qty: 0, exp: 40},
+        {duration: 72e3, qty: 0, exp: 75},
+        {duration: 158e3, qty: 0, exp: 120},
+        {duration: 518e3, qty: 0, exp: 350}
     ],
     [
-        [10800, 5, 10, 1],
-        [216e3, 50, 80, 1],
-        [432e3, 100, 160, 1],
-        [72e3, 1, 60, 1]
+        {duration: 10800, qty: 5, shiny: 10},
+        {duration: 216e3, qty: 50, shiny: 80},
+        {duration: 432e3, qty: 100, shiny: 160},
+        {duration: 72e3, qty: 1, shiny: 60}
     ],
     [
-        [3600, 3, 3, 0],
-        [36e3, 15, 12, 0],
-        [108e3, 40, 30, 0],
-        [72e4, 220, 200, 0]
+        {duration: 3600, qty: 3, exp: 3},
+        {duration: 36e3, qty: 15, exp: 12},
+        {duration: 108e3, qty: 40, exp: 30},
+        {duration: 72e4, qty: 220, exp: 200}
     ],
     [
-        [1200, 2, 4, 1],
-        [3600, 4, 8, 1],
-        [36e3, 21, 38, 1],
-        [144e3, 70, 125, 1],
-        [576e3, 250, 375, 1],
-        [2419e3, 550, 1150, 1]
+        {duration: 1200, qty: 2, shiny: 4},
+        {duration: 3600, qty: 4, shiny: 8},
+        {duration: 36e3, qty: 21, shiny: 38},
+        {duration: 144e3, qty: 70, shiny: 125},
+        {duration: 576e3, qty: 250, shiny: 375},
+        {duration: 2419e3, qty: 550, shiny: 1150}
     ],
 ];
 
@@ -91,34 +95,38 @@ export class Trap {
         }
     }
 
-    static getMaxTraps = (trap: Item | undefined) => {
-        if (trap == undefined) {
-            return 1;
-        }
-        switch (trap.internalName) {
-            case "TrapBoxSet1": return 1;
-            case "TrapBoxSet2": return 2;
-            case "TrapBoxSet3": return 3;
-            case "TrapBoxSet4": return 4;
-            case "TrapBoxSet5": return 5;
-            case "TrapBoxSet6": return 6;
-            case "TrapBoxSet7": return 7;
-            case "TrapBoxSet8": return 7;
-            default: return 1;
-        }
+    static getMaxTraps = (trap: Item | undefined, hasAlchemyExtraTrap: boolean) => {
+        const baseTraps = (() => {
+            if (trap == undefined) {
+                return 0;
+            }
+            switch (trap.internalName) {
+                case "TrapBoxSet1": return 1;
+                case "TrapBoxSet2": return 2;
+                case "TrapBoxSet3": return 3;
+                case "TrapBoxSet4": return 4;
+                case "TrapBoxSet5": return 5;
+                case "TrapBoxSet6": return 6;
+                case "TrapBoxSet7": return 7;
+                case "TrapBoxSet8": return 7;
+                default: return 1;
+            }
+        })();
+        return baseTraps + (hasAlchemyExtraTrap ? 1 : 0);
     }
 
     getBenefits = () => {
-        const boxData = trapBoxInfo[this.trapType].find(info => Math.round(info[0]) == Math.round(this.trapDuration));
-        if (boxData) {
-            if (boxData[3] == 0) {
-                return [`x${Math.round(boxData[1] * 10) / 10} Qty`, `x${Math.round(boxData[2] * 10) / 10} Exp`]
-            }
-            if (boxData[3] == 1) {
-                return [`x${Math.round(boxData[1] * 10) / 10} Qty`, `x${Math.round(boxData[2] * 10) / 10} Shiny`]
-            }
+        const boxData = trapBoxInfo[this.trapType].find(trap => trap.duration == this.trapDuration);
+        if (!boxData) return [];
+
+        const benefits = [`x${boxData.qty} Qty`]
+        if ("exp" in boxData) {
+            benefits.push(`x${boxData.exp} Exp`)
         }
-        return [];
+        if ("shiny" in boxData) {
+            benefits.push(`x${boxData.shiny} Shiny`)
+        }
+        return benefits;
     }
 }
 


### PR DESCRIPTION
- Used alchemy 'Call Me Ash' for 'maxTraps' calculation instead of having hard-coded '+1';
- Added 'Bonuses' label for Qty, Exp, Shiny bonuses and made them appear in one line:
<img width="271" height="144" alt="image" src="https://github.com/user-attachments/assets/d5450e72-23fc-4d3f-b9a0-29521f84cbcc" />

- Small refactoring of the `data/domain/world-3/traps.tsx`:
  - Added `TrapBoxInfo` union type to represent `Exp` and `Shiny` variants;
  - Converted `trapBoxInfo` entries from tuple arrays to typed objects;
  - Simplified `getBenefits()`;