### PR TITLE
Fix Seraph star sign and Exotic Market upgrade for prisma bonus multipliers

### DIFF
--- a/data/domain/starsigns.tsx
+++ b/data/domain/starsigns.tsx
@@ -1,9 +1,10 @@
 import { Domain } from './base/domain';
 import { RawData } from './base/domain';
 import { Item } from "./items";
-import { Summoning } from "./world-6/summoning";
 import { InfiniteStarsBonus, Rift } from "./world-4/rift";
 import { Tesseract } from './tesseract';
+import type { Player } from './player';
+import { SkillsIndex } from './SkillsIndex';
 
 interface StarBonus {
     text: string,
@@ -89,7 +90,7 @@ export class StarSigns extends Domain  {
 
     getSeraphCosmosBonus = (): number => {
         if (this.isStarSignUnlocked("Seraph Cosmos")) {
-            return Math.min(3, Math.pow(1.1 + Math.min(this.tesseractBonusToSeraph, 10) / 100, Math.ceil((this.summoningLevel + 1) / 20)));
+            return Math.min(5, Math.pow(1.1 + Math.min(this.tesseractBonusToSeraph, 10) / 100, Math.ceil((this.summoningLevel + 1) / 20)));
         } else {
             return 1;
         }
@@ -109,10 +110,10 @@ export class StarSigns extends Domain  {
 
 export const updateStarSignsUnlocked = (data: Map<string, any>) => {
     const starSigns = data.get("starsigns") as StarSigns;
-    const summoning = data.get("summoning") as Summoning;
+    const players = data.get("players") as Player[];
     const tesseract = data.get("tesseract") as Tesseract;
 
-    starSigns.summoningLevel = summoning.summoningLevel;
+    starSigns.summoningLevel = Math.max(...players.map(player => player.skills.get(SkillsIndex.Summoning)?.level ?? 0));
     starSigns.tesseractBonusToSeraph = tesseract.getUpgradeBonus(40);
     const seraphCosmosBonus = starSigns.getSeraphCosmosBonus();
     starSigns.unlockedStarSigns.filter(sign => !["Chronus Cosmos", "Hydron Cosmos", "Seraph Cosmos"].includes(sign.name)).forEach(sign => {

--- a/data/domain/world-2/alchemy/alchemy.tsx
+++ b/data/domain/world-2/alchemy/alchemy.tsx
@@ -28,6 +28,7 @@ import { Tesseract } from '../../tesseract';
 import { Arcade } from '../arcade';
 import { LegendTalent, LegendTalents } from '../../world-7/legendTalents';
 import { Sigils } from './sigils';
+import type { Farming } from '../../world-6/farming';
 
 export enum CauldronIndex {
     Power = 0,
@@ -948,6 +949,7 @@ export function updateAlchemy(data: Map<string, any>) {
     const slab = data.get("slab") as Slab;
     const legendTalents = data.get("legendTalents") as LegendTalents;
     const sigils = data.get("sigils") as Sigils;
+    const farming = data.get("farming") as Farming;
 
     const vaultBonus42 = vault.getBonusForId(42);
     const labBonusActive = lab.bonuses.find(bonus => bonus.name == "My 1st Chemistry Set")?.active ?? false;
@@ -1024,10 +1026,9 @@ export function updateAlchemy(data: Map<string, any>) {
     const paletteBonus28 = 0;
     const legendBonus36 = legendTalents.getBonusFromIndex(36);
     const purpleSigilsBonus = sigils.sigils.reduce((sum, sigil) => sum += (sigil.boostLevel >= 4 ? 1: 0), 0);
-    // TODO : add this once farming is updated with exotic market
-    const exoticMarketBonus48 = 0;
+    const exoticMarketBonus48 = farming.getExoticMarketBonusValue(48);
 
-    const prismaBonus = Math.min(3, 2 + (arcaneBonus45 + arcadeBonus54 + world6TrophyBonus + paletteBonus28 + .2 * purpleSigilsBonus + exoticMarketBonus48 + legendBonus36) / 100);
+    const prismaBonus = Math.min(4, 2 + (arcaneBonus45 + arcadeBonus54 + world6TrophyBonus + paletteBonus28 + .2 * purpleSigilsBonus + exoticMarketBonus48 + legendBonus36) / 100);
     
     alchemy.cauldrons.flatMap(cauldron => cauldron.bubbles).forEach(bubble => {
         if (bubble.prismatic) {

--- a/data/domain/world-6/farming.tsx
+++ b/data/domain/world-6/farming.tsx
@@ -24,6 +24,10 @@ import { TaskBoard } from "../tasks";
 import { Grimoire } from "../grimoire";
 import { LegendTalents } from "../world-7/legendTalents";
 
+const exoticMarketBonusData: Record<number, { bonusPerLevel: number, diminishing: boolean }> = {
+    48: { bonusPerLevel: 2, diminishing: true }, // Prisma Bubble Bonus
+};
+
 export class LandRankDataBase {
     unlocked: boolean = false;
     upgrades: LandRankUpgrade[] = [];
@@ -497,6 +501,7 @@ export class Farming extends Domain {
     growthRate: number = 0;
     magicBeansFromDepot: number = 0;
     discoveredCrops: number = 0;
+    exoticMarketLevels: number[] = [];
 
     cropNames = ["Apple", "Orange", "Lemon", "Pear", "Strawberry", "Bananas", "Blueberry", "Red Grapes", "Red Pear", "Pineapple", "Lime", "Raspberry", "Fig", "Peach", "Purple Grapes", "Yellow Pear", "Watermelon", "Green Grapes", "Dragon Fruit", "Mango", "Gold Blueberry",
         "Carrot", "Potato", "Beat", "Tomato", "Artichoke", "Roma Tomato", "Butternut Squash", "Avocado", "Red Pepper", "Broccoli", "Beatroot", "Coconut", "Sliced Tomato", "Cashew", "Turnip", "Coffee Bean", "Pumpkin", "Sliced Cucumber", "Eggplant", "Lettuce", "Garlic", "Green Beans", "Bell Pepper", "Corn", "Gold Sliced Tomato",
@@ -535,6 +540,7 @@ export class Farming extends Domain {
         }
 
         const upgradesLevels = upgradesData.slice(2, -2);
+        farming.exoticMarketLevels = upgradesData.slice(20, 100);
 
         farming.magicBeansOwned = upgradesData[1];
         farming.instaGrowToolLeft = upgradesData[19];
@@ -720,6 +726,20 @@ export class Farming extends Domain {
         } else {
             return 0;
         }
+    }
+
+    getExoticMarketBonusValue = (bonusId: number): number => {
+        const bonusData = exoticMarketBonusData[bonusId];
+        if (!bonusData) {
+            return 0;
+        }
+
+        const level = this.exoticMarketLevels[bonusId] ?? 0;
+        if (bonusData.diminishing) {
+            return bonusData.bonusPerLevel * (level / (1000 + level));
+        }
+
+        return bonusData.bonusPerLevel * level;
     }
 
     getMarketUpgradeBonusText = (upgradeId: number): string => {

--- a/data/domain/world-6/farming.tsx
+++ b/data/domain/world-6/farming.tsx
@@ -24,6 +24,7 @@ import { TaskBoard } from "../tasks";
 import { Grimoire } from "../grimoire";
 import { LegendTalents } from "../world-7/legendTalents";
 
+// TODO: This is a temporary solution until proper Exotic Market implementation
 const exoticMarketBonusData: Record<number, { bonusPerLevel: number, diminishing: boolean }> = {
     48: { bonusPerLevel: 2, diminishing: true }, // Prisma Bubble Bonus
 };

--- a/tests/domains/cooking/meal-speed-parameters.test.ts
+++ b/tests/domains/cooking/meal-speed-parameters.test.ts
@@ -9,7 +9,6 @@ import { loadExtractionResults, validateExtractionHealth, getExtractedValue } fr
 import { loadGameDataFromSave } from '../../utils/cloudsave-loader';
 import { ParameterTestSpec } from '../../utils/parameter-test-config';
 import { Cooking } from '../../../data/domain/world-4/cooking';
-import { StarSigns } from '../../../data/domain/starsigns';
 import { CropScientistBonusText, Farming } from '../../../data/domain/world-6/farming';
 import { Player } from '../../../data/domain/player';
 import { Votes } from '../../../data/domain/world-2/votes';
@@ -65,8 +64,8 @@ const cookingParameterSpecs: Record<string, ParameterTestSpec> = {
     description: 'Star sign cooking speed bonus',
     extractionKey: 'starsign_58_bonus',
     domainExtractor: (gameData) => {
-      const starSigns = gameData.get("starsigns") as StarSigns;
-      const starsign58 = starSigns.unlockedStarSigns.find(sign => sign.name == "Gordonius Major")?.getBonus("Cooking SPD (Multiplicative!)") ?? 0;
+      const players = gameData.get('players') as Player[];
+      const starsign58 = players[0].starSigns.find(sign => sign.name == "Gordonius Major")?.getBonus("Cooking SPD (Multiplicative!)") ?? 0;
       return starsign58;
     },
   },


### PR DESCRIPTION
This is the previous execution with failed cooking tests: https://github.com/Sludging/idleon-efficiency/actions/runs/26492458999/job/78012992879?pr=317#step:9:6

You can see that tests are fixed in current PR execution: https://github.com/Sludging/idleon-efficiency/actions/runs/26558356539/job/78235137596?pr=318#step:9:6