### PR TITLE
Fix build speed tests for players

### DIFF
--- a/data/domain/player.tsx
+++ b/data/domain/player.tsx
@@ -461,12 +461,11 @@ export class Player {
         this.crystalChance.sources.push({ name: "Post Office", value: postOfficeBonus });
     }
 
-    setBuildSpeed = (stampsBonusBuildProd: number, constructionBubbleBonus: number, guildBonus5: number, achievement153: number, constructionMasteryBonus: number, 
+    setBuildSpeed = (stampsBonusBuildProd: number, constructionBubbleBonus: number, guildBonus5: number, gearBonus: number, achievement153: number, constructionMasteryBonus: number,
         vialBonusContspd: number, turtleVialBonus: number, arcadeBonus44: number, votingBonus18: number, vaultUpgrade48: number, sheepiesKilled: number,
         bubbaBonus1: number, atomCollider1: number, redoxSaltInStorage: number, winnerBonus13: number, paletteBonus25: number) => {
         const constructionLevel = this.skills.get(SkillsIndex.Construction)?.level || 0;
-        const redoxSaltTalent = this.talents.find(x => x.skillIndex == 131)?.getBonus() ?? 0;
-        const gearBonus = this.getMiscBonusFromGear("Build Spd");
+        const redoxSaltTalentBonus = this.talents.find(x => x.skillIndex == 131)?.getBonusFromPointsSpent() ?? 0;
         let postOfficeBonus = 0;
         if (this.postOffice) {
             const constructionBox = this.postOffice.find(box => box.name == "Construction Container");
@@ -477,16 +476,16 @@ export class Player {
 
         const baseSpeed = 3 * Math.pow(constructionLevel / 2 + .7, 1.6);
         const bubbleBonus = 1 + constructionLevel * constructionBubbleBonus / 100;
-        const talentBonus = (1 + redoxSaltTalent * (atomCollider1 + lavaLog(redoxSaltInStorage)) / 100);
+        const talentBonus = (1 + redoxSaltTalentBonus * (atomCollider1 + lavaLog(redoxSaltInStorage)) / 100);
         const winnerBonus = 1 + winnerBonus13 / 100;
         const paletteBonus = 1 + paletteBonus25 / 100;
         const vialTurtleBonus = 1 + turtleVialBonus / 100;
         const vaultBonus = vaultUpgrade48 * Math.floor(lavaLog(sheepiesKilled));
-        const totalAdditivePoints = stampsBonusBuildProd + postOfficeBonus + guildBonus5 + gearBonus + achievement153 + constructionMasteryBonus + vialBonusContspd + 
-                                    arcadeBonus44 + votingBonus18 + vaultBonus + bubbaBonus1;        
+        const totalAdditivePoints = stampsBonusBuildProd + postOfficeBonus + guildBonus5 + gearBonus + achievement153 + constructionMasteryBonus + vialBonusContspd +
+            arcadeBonus44 + votingBonus18 + vaultBonus + bubbaBonus1;
         const additiveBonuses = 1 + totalAdditivePoints / 100;
 
-        const totalSpeed = baseSpeed * bubbleBonus * additiveBonuses * talentBonus * winnerBonus * paletteBonus * vialTurtleBonus;
+        const totalSpeed = baseSpeed * bubbleBonus * additiveBonuses * winnerBonus * paletteBonus * vialTurtleBonus * talentBonus;
         this.buildSpeed.value = totalSpeed;
         const totalBonusSpeed = totalSpeed - baseSpeed;
 
@@ -1470,6 +1469,10 @@ export const playerExtraCalculations = (data: Map<string, any>) => {
     const redoxSaltsOwned = storage.amountInStorage("Refinery1");
     const winnerBonus13 = summoning.summonBonuses.find(bonus => bonus.index == 13)?.getBonus() || 0;
     const paletteBonus25 = gaming.getPaletteBonus(25);
+    // EtcBonuses("30") reads the active character even when PlayerBuildSpd targets another player.
+    const activePlayer = players.reduce<Player | undefined>((closest, player) =>
+        !closest || player.afkFor < closest.afkFor ? player : closest, undefined);
+    const activePlayerGearBonus = activePlayer?.getMiscBonusFromGear("Build Spd") ?? 0;
 
     // Apply everything to players
     players.forEach(player => {
@@ -1494,7 +1497,7 @@ export const playerExtraCalculations = (data: Map<string, any>) => {
 
         // Build Speed
         const constructionBubbleBonus = alchemy.getBonusForPlayer(player, CauldronIndex.Power, 12);
-        player.setBuildSpeed(buildSpeedStampBonus, constructionBubbleBonus, guildBonus5, achievement153, constructionMasteryBonus, vialEquinoxFishBonus, vialTurtleBonus,
+        player.setBuildSpeed(buildSpeedStampBonus, constructionBubbleBonus, guildBonus5, activePlayerGearBonus, achievement153, constructionMasteryBonus, vialEquinoxFishBonus, vialTurtleBonus,
             arcadeBonus44, votingBonus18, vaultUpgrade48, sheepiesKilled, bubbaBonus1, atomCollider1, redoxSaltsOwned, winnerBonus13, paletteBonus25);
     });
 

--- a/data/domain/player.tsx
+++ b/data/domain/player.tsx
@@ -484,8 +484,9 @@ export class Player {
         const totalAdditivePoints = stampsBonusBuildProd + postOfficeBonus + guildBonus5 + gearBonus + achievement153 + constructionMasteryBonus + vialBonusContspd +
             arcadeBonus44 + votingBonus18 + vaultBonus + bubbaBonus1;
         const additiveBonuses = 1 + totalAdditivePoints / 100;
+        const accountMultipliers = winnerBonus * paletteBonus * vialTurtleBonus;
 
-        const totalSpeed = baseSpeed * bubbleBonus * additiveBonuses * winnerBonus * paletteBonus * vialTurtleBonus * talentBonus;
+        const totalSpeed = baseSpeed * bubbleBonus * additiveBonuses * accountMultipliers * talentBonus;
         this.buildSpeed.value = totalSpeed;
         const totalBonusSpeed = totalSpeed - baseSpeed;
 

--- a/data/domain/player.tsx
+++ b/data/domain/player.tsx
@@ -465,7 +465,7 @@ export class Player {
         vialBonusContspd: number, turtleVialBonus: number, arcadeBonus44: number, votingBonus18: number, vaultUpgrade48: number, sheepiesKilled: number,
         bubbaBonus1: number, atomCollider1: number, redoxSaltInStorage: number, winnerBonus13: number, paletteBonus25: number) => {
         const constructionLevel = this.skills.get(SkillsIndex.Construction)?.level || 0;
-        const redoxSaltTalentBonus = this.talents.find(x => x.skillIndex == 131)?.getBonusFromPointsSpent() ?? 0;
+        const redoxSaltTalentBonus = this.talents.find(x => x.skillIndex == 131)?.getBonus() ?? 0;
         let postOfficeBonus = 0;
         if (this.postOffice) {
             const constructionBox = this.postOffice.find(box => box.name == "Construction Container");

--- a/data/domain/talents.tsx
+++ b/data/domain/talents.tsx
@@ -54,12 +54,6 @@ export class Talent {
         return this.getBonusAtLevel(maxBonus ? this.maxLevel : this.level, round, yBonus);
     }
 
-    // Confirmed to be needed for the 'Redox Rates' talent (131)
-    // Other potential talents are: 42, 43, 78, 132, 281, 491,493
-    getBonusFromPointsSpent = (round: boolean = false, yBonus: boolean = false) => {
-        return this.getBonusAtLevel(this.pointsSpent, round, yBonus);
-    }
-
     getBonusText = (): string => {
         const xBonus = this.getBonus(true);
         const yBonus = this.getBonus(true, true);
@@ -101,6 +95,8 @@ export class Talent {
         switch(talentInfo.skillIndex) {
             case 59:
                 return new BloodMarrowTalent(talentName, talentInfo);
+            case 131:
+                return new RedoxRatesTalent(talentName, talentInfo);
             case 146:
                 return new ApocalypseChowTalent(talentName, talentInfo);
             default:
@@ -121,6 +117,13 @@ export class BloodMarrowTalent extends Talent {
 
     override getBonusText = (): string => {
         return `${this.getBonus()}% - ${this.totalMeals} Meals`;
+    }
+}
+
+// Other potential talents with this logic are: 42, 43, 78, 132, 281, 491,493
+export class RedoxRatesTalent extends Talent {
+    override getBonus = (round: boolean = false, yBonus: boolean = false) => {
+        return super.getBonusAtLevel(this.pointsSpent, round, yBonus);
     }
 }
 

--- a/data/domain/talents.tsx
+++ b/data/domain/talents.tsx
@@ -43,12 +43,21 @@ export class Talent {
         this.skillIndex = data.skillIndex;
     }
 
-    getBonus = (round: boolean = false, yBonus: boolean = false, maxBonus: boolean = false) => {
-        const level = maxBonus ? this.maxLevel : this.level
+    protected getBonusAtLevel(level: number, round: boolean = false, yBonus: boolean = false) {
         if (yBonus) {
             return lavaFunc(this.funcY, level, this.y1, this.y2, round);
         }
         return lavaFunc(this.funcX, level, this.x1, this.x2, round);
+    }
+
+    getBonus = (round: boolean = false, yBonus: boolean = false, maxBonus: boolean = false) => {
+        return this.getBonusAtLevel(maxBonus ? this.maxLevel : this.level, round, yBonus);
+    }
+
+    // Confirmed to be needed for the 'Redox Rates' talent (131)
+    // Other potential talents are: 42, 43, 78, 132, 281, 491,493
+    getBonusFromPointsSpent = (round: boolean = false, yBonus: boolean = false) => {
+        return this.getBonusAtLevel(this.pointsSpent, round, yBonus);
     }
 
     getBonusText = (): string => {
@@ -103,16 +112,9 @@ export class Talent {
 export class BloodMarrowTalent extends Talent {
     totalMeals: number = 0;
 
-    getBonus = (round: boolean = false, yBonus: boolean = false, maxBonus: boolean = false) => {
-        // TODO: I don't like duplicating code, but this is a special case so I'm leaving it for now.
-        let baselineBonus = 0;
-        const level = maxBonus ? this.maxLevel : this.level
-        if (yBonus) {
-            baselineBonus = lavaFunc(this.funcY, level, this.y1, this.y2, round);
-        } else {
-            baselineBonus = lavaFunc(this.funcX, level, this.x1, this.x2, round);
-        }
-        
+    protected override getBonusAtLevel(level: number, round: boolean = false, yBonus: boolean = false) {
+        const baselineBonus = super.getBonusAtLevel(level, round, yBonus);
+
         // Actual special calculation for Blood Marrow.
         return Math.pow(Math.min(1.012, 1 + (baselineBonus / 100)), this.totalMeals);
     }
@@ -215,4 +217,3 @@ export const GetTalentArray = (page: string): Talent[] => {
         return Talent.fromBase(talentName, talentInfo);
     });
 }
-

--- a/data/domain/world-2/votes.tsx
+++ b/data/domain/world-2/votes.tsx
@@ -93,7 +93,7 @@ export const updateVotesBonus = (data: Map<string, any>) => {
     const companion19 = companions.find(companion => companion.id == 19);
     const multiFromCompanion19 = companion19?.owned || false ? companion19.data.bonus : 0;
     const multiFromDream13 = (equinox.upgrades[11]?.getBonus() ?? 0);
-    const multiFromHoleCosmo = hole.majiks.IdleonUpgrades.find(upgrade => upgrade.index == 3)?.getBonus() ?? 0;
+    const multiFromHoleCosmo = hole.majiks.IdleonUpgrades.find(upgrade => upgrade.index == 24)?.getBonus() ?? 0;
     const multiFromSUmmoningWinningBonus22 = summoning.summonBonuses.find(bonus => bonus.index == 22)?.getBonus() ?? 0;
     const multiFromEventShop7 = eventShop.isBonusOwned(7) ? 17 : 0;
     const multiFromEventShop16 = eventShop.isBonusOwned(16) ? 13 : 0;

--- a/tests/domains/player/player-build-speed-parameters.test.ts
+++ b/tests/domains/player/player-build-speed-parameters.test.ts
@@ -144,11 +144,13 @@ const parameterSpecs = {
     }
   },
   gear_bonus_etc_bonuses_30: {
-    description: 'Gear bonus from EtcBonuses 30 (tested for player 0)',
+    description: 'Active character gear bonus from EtcBonuses 30',
     extractionKey: 'gear_bonus_etc_bonuses_30',
     domainExtractor: (gameData: Map<string, any>) => {
       const players = gameData.get("players") as Player[];
-      return players[0].getMiscBonusFromGear("Build Spd");
+      const activePlayer = players.reduce<Player | undefined>((closest, player) =>
+        !closest || player.afkFor < closest.afkFor ? player : closest, undefined);
+      return activePlayer?.getMiscBonusFromGear("Build Spd") ?? 0;
     }
   },
 };


### PR DESCRIPTION
1. Fixed Hole upgrade index in the Ballot class;
2. Changed the calculation of the Redox Salt talent (it doesn't consider bonus levels from other sources, only number of talent points invested);
3. Changed the order of bonuses that are multiplied in `totalSpeed` variable (now they are according to the game formula);
4. Changed how gear bonus is calculated for every player (it is the same for all players and is calculated from the current or last played player).